### PR TITLE
Renamed "Event Hook" to "Run Task"; Added HMAC step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # Description
-This repo contains files in support of an integration between Sophos Factory and Terraform Cloud. The goal is to insert an intermediary step in the Terraform Cloud workflow by way of a Sophos Factory pipeline that can execute any number of tasks, such as an ```opa eval``` scan, Terrascan, or Checkov scan using Terraform Cloud's **Event Hook** feature to trigger a Sophos Factory pipeline via WebHook.
+This repo contains files in support of an integration between Sophos Factory and Terraform Cloud. The goal is to insert a **Run Task** in the Terraform Cloud workflow that runs a Sophos Factory job configured with a WebHook trigger which will subsequently execute a Sophos factory pipeline which could be configured to execute any number of tasks, such as an ```opa eval``` scan, Terrascan, or Checkov scan and then send the result back to Terraform Cloud's calling **Run Task**.
 
 The basic flow looks like this:
 
-Terraform Plan ➡ Event Hook ➡ Sophos Factory WebHook ➡ Sophos Factory Pipeline ➡ Back to Event Hook ➡ Deploy
+* Terraform Cloud Run
+* Terraform Cloud Run Task
+* Sophos Factory Job (WebHook Trigger)
+* Sophos Factory Pipeline
+* Reply Back to Terraform Cloud Run Task
+* Finish Terraform Cloud Workflow
 
 The inspiration for this example comes from the [Open Policy Agent | Terraform](https://www.openpolicyagent.org/docs/latest/terraform/) use case. The files listed in the instructions above have been added to this repo.
 
@@ -22,18 +27,23 @@ The inspiration for this example comes from the [Open Policy Agent | Terraform](
 * In Sophos Factory
     * Create a new Job using the following settings:
         * Trigger: **Incoming WebHook**
+        * Webhook Type: **Terraform Cloud Run Task**
+        * (Optional) Terraform Secret Token: (A Generic Secret credential with an HMAC value)
         * Variables Transform: ```{"data": body | dump}```
-        * Pipeline: *choose one of the following example pipelines*
-            * **Terraform Cloud Event Hook | OPA Eval**
-            * **Terraform Cloud Event Hook | Terrascan**
-            * **Terraform Cloud Event Hook | Checkov**
+        * Pipeline Options:
+            * Catalog: *choose one of the following example pipelines*
+                * **Terraform Cloud Run Task | OPA Eval**
+                * **Terraform Cloud Run Task | Terrascan**
+                * **Terraform Cloud Run Task | Checkov**
         * Revision: **latest**
+    * Click *Create*
     * Copy the WebHook URL for use later
 * In Terraform Cloud
     * Create a new Event Hook (YourOrg ➡ Settings ➡ Task event hooks ➡ Create event hook)
         * Name: *Choose a descriptive name*
-        * Hook endpoint URL: *Paste in the WebHook URL from the Sophos Factory job*
-    * Create a new workspace in Terraform Cloud using the following settings:
+        * Endpoint URL: *Paste in the WebHook URL from the Sophos Factory job*
+        * HMAC (optional): *Paste in the HMAC used earlier*
+    * Create a new workspace (if one does not already exist) in Terraform Cloud using the following settings:
         * Version Control Workflow
             * Provider: **GitHub**
             * ID: ```refactr/opa-terraform-demo```
@@ -50,10 +60,11 @@ The inspiration for this example comes from the [Open Policy Agent | Terraform](
             * Feel free to cancel the plan
 
 ## Resources
-* [Create a Terraform Cloud account](https://app.terraform.io/signup/account)
-* [Sophos Factory Community Edition](https://www.refactr.it/community-edition)
-* [Create AWS Account](https://aws.amazon.com/resources/create-account/)
-* [Sophos Factory Webhook Job Trigger](https://docs.refactr.it/docs/running-pipelines/#incoming-webhook-job-trigger)
+* [Sophos Factory | Community Edition](https://www.refactr.it/community-edition)
+* [Sophos Factory | Webhook Job Trigger](https://docs.refactr.it/docs/running-pipelines/#incoming-webhook-job-trigger)
+* [Terraform Cloud | Create Account](https://app.terraform.io/signup/account)
+* [Terraform Cloud | Run Tasks](https://www.terraform.io/docs/cloud/workspaces/run-tasks.html)
+* [Terraform Cloud | Run Tasks API](https://www.terraform.io/docs/cloud/api/run-tasks.html)
+* [AWS | Create Account](https://aws.amazon.com/resources/create-account/)
 * [Open Policy Agent | Terraform](https://www.openpolicyagent.org/docs/latest/terraform/)
-* [Run Tasks](https://www.terraform.io/docs/cloud/workspaces/run-tasks.html)
-* [Run Tasks API](https://www.terraform.io/docs/cloud/api/run-tasks.html)
+

--- a/main.tf
+++ b/main.tf
@@ -1,23 +1,18 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# Configure the AWS Provider
 provider "aws" {
-    region = "us-west-1"
+  region = "us-west-2"
 }
-resource "aws_instance" "web" {
-  instance_type = "t2.micro"
-  ami = "ami-09b4b74c"
-}
-resource "aws_autoscaling_group" "my_asg" {
-  availability_zones        = ["us-west-1a"]
-  name                      = "my_asg"
-  max_size                  = 5
-  min_size                  = 1
-  health_check_grace_period = 300
-  health_check_type         = "ELB"
-  desired_capacity          = 4
-  force_delete              = true
-  launch_configuration      = "my_web_config"
-}
-resource "aws_launch_configuration" "my_web_config" {
-    name = "my_web_config"
-    image_id = "ami-09b4b74c"
-    instance_type = "t2.micro"
+
+# Create a VPC
+resource "aws_vpc" "opa-terraform-demo" {
+  cidr_block = "10.0.0.0/16"
 }


### PR DESCRIPTION
HashiCorp wants to get away from the term **Event Hooks** and use **Run Tasks** instead. Also added a few lines to explain how to use the HMAC validation.